### PR TITLE
remove dependency on ADNL connection

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -84,7 +84,7 @@ func main() {
 	tracer := sources.NewTracer(log, storage, source)
 	go tracer.Run(context.TODO())
 
-	idx := indexer.New(log, client)
+	idx := indexer.New(log, client, nil)
 	go idx.Run(context.TODO(), []chan indexer.IDandBlock{
 		pusherBlockCh,
 		storageBlockCh,

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/arnac-io/opentonapi
 
-go 1.21.0
+go 1.21.3
 
-toolchain go1.22.0
+toolchain go1.22.1
 
 require (
 	github.com/BurntSushi/toml v1.2.1
@@ -69,10 +69,12 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/r3labs/sse/v2 v2.10.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/snksoft/crc v1.1.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
+	github.com/tonkeeper/tonapi-go v0.0.7 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
@@ -82,6 +84,7 @@ require (
 	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/puzpuzpuz/xsync/v2 v2.4.0 h1:5sXAMHrtx1bg9nbRZTOn8T4MkWe5V+o8yKRH02Eznag=
 github.com/puzpuzpuz/xsync/v2 v2.4.0/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
+github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
+github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
@@ -366,6 +368,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tonkeeper/scam_backoffice_rules v0.0.0-20240822052421-6e4f645f0bc7 h1:VqaRW2kQejlVbDSELpux57NSrdFzOBNvyEb3kaDWnsY=
 github.com/tonkeeper/scam_backoffice_rules v0.0.0-20240822052421-6e4f645f0bc7/go.mod h1:m8OU6RRwyWQxvEgSDNnXuGPEbKxtneeJ6nIxsEMAvBU=
+github.com/tonkeeper/tonapi-go v0.0.7 h1:wNQqrzmeMSszyjr+msRGP8R1z9P2/YGVLy73KOLl6Ns=
+github.com/tonkeeper/tonapi-go v0.0.7/go.mod h1:PG6YMPOsOwP39/OR8NWxrf4NE34qXR7uupNsUlHd3rE=
 github.com/tonkeeper/tongo v1.9.2 h1:nObxrR77V1CIajfoHenKgN11edhfmLqyAiXTBvaNXEU=
 github.com/tonkeeper/tongo v1.9.2/go.mod h1:MjgIgAytFarjCoVjMLjYEtpZNN1f2G/pnZhKjr28cWs=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -456,6 +460,7 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191105084925-a882066a44e0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -694,6 +699,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
+gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/arnac-io/opentonapi/pkg/chainstate"
 	"github.com/arnac-io/opentonapi/pkg/core"
 	"github.com/arnac-io/opentonapi/pkg/rates"
 	"github.com/go-faster/errors"
@@ -164,9 +163,7 @@ func NewHandler(logger *zap.Logger, opts ...Option) (*Handler, error) {
 	if options.storage == nil {
 		return nil, errors.New("storage is not configured")
 	}
-	if options.chainState == nil {
-		options.chainState = chainstate.NewChainState(options.storage)
-	}
+
 	if options.ratesSource == nil {
 		options.ratesSource = rates.Mock{}
 	}

--- a/pkg/fordefi_test.go
+++ b/pkg/fordefi_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/arnac-io/opentonapi/pkg/core"
 	"github.com/arnac-io/opentonapi/pkg/litestorage"
 	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/tonapi-go"
 	"github.com/tonkeeper/tongo"
-	"github.com/tonkeeper/tongo/liteapi"
 )
 
 func mustNewCache[T any](t *testing.T) litestorage.ICache[T] {
@@ -23,14 +23,16 @@ func mustNewCache[T any](t *testing.T) litestorage.ICache[T] {
 }
 
 func mustNewLiteStorage(t *testing.T) *litestorage.LiteStorage {
-	client, err := liteapi.NewClientWithDefaultMainnet()
+	tonapi, err := tonapi.New(tonapi.WithToken("AGKK3WIHTERSIGYAAAAFKMOJOFT7IGZJRMQDAHGG5UTVRFBUAR5TUC2MJ4U45BC7OFPQZAI"))
 	require.NoError(t, err)
+
 	storage, err := litestorage.NewLiteStorage(
 		zap.L(),
-		client,
+		nil,
 		litestorage.WithTrackAllAccounts(),
 		litestorage.WithTransactionsIndexByHash(mustNewCache[core.Transaction](t)),
 		litestorage.WithTransactionsByInMsgLT(mustNewCache[string](t)),
+		litestorage.WithTonApiClient(tonapi),
 	)
 	require.NoError(t, err)
 	return storage
@@ -93,9 +95,10 @@ func TestIndexer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := liteapi.NewClientWithDefaultMainnet()
+			tonapi, err := tonapi.New(tonapi.WithToken("AGKK3WIHTERSIGYAAAAFKMOJOFT7IGZJRMQDAHGG5UTVRFBUAR5TUC2MJ4U45BC7OFPQZAI"))
 			require.NoError(t, err)
-			opentonIndexer := indexer.New(zap.L(), client)
+
+			opentonIndexer := indexer.New(zap.L(), nil, tonapi)
 			masterBlock, blocks, err := opentonIndexer.GetBlocksFromMasterBlock(test.blockNumber)
 			require.NoError(t, err)
 			require.Len(t, blocks, test.expectedBlocks)
@@ -123,9 +126,10 @@ func TestLiteStorage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := liteapi.NewClientWithDefaultMainnet()
+			tonapi, err := tonapi.New(tonapi.WithToken("AGKK3WIHTERSIGYAAAAFKMOJOFT7IGZJRMQDAHGG5UTVRFBUAR5TUC2MJ4U45BC7OFPQZAI"))
 			require.NoError(t, err)
-			opentonIndexer := indexer.New(zap.L(), client)
+
+			opentonIndexer := indexer.New(zap.L(), nil, tonapi)
 			_, blocks, err := opentonIndexer.GetBlocksFromMasterBlock(test.blockNumber)
 			require.NoError(t, err)
 
@@ -186,9 +190,10 @@ func TestHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := liteapi.NewClientWithDefaultMainnet()
+			tonapi, err := tonapi.New(tonapi.WithToken("AGKK3WIHTERSIGYAAAAFKMOJOFT7IGZJRMQDAHGG5UTVRFBUAR5TUC2MJ4U45BC7OFPQZAI"))
 			require.NoError(t, err)
-			opentonIndexer := indexer.New(zap.L(), client)
+
+			opentonIndexer := indexer.New(zap.L(), nil, tonapi)
 			liteStorage := mustNewLiteStorage(t)
 
 			for _, blockNumber := range test.blockNumbers {

--- a/pkg/litestorage/litestorage.go
+++ b/pkg/litestorage/litestorage.go
@@ -3,6 +3,8 @@ package litestorage
 import (
 	"context"
 	"crypto/ed25519"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -15,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/puzpuzpuz/xsync/v2"
 	"github.com/sourcegraph/conc/iter"
+	"github.com/tonkeeper/tonapi-go"
 	"github.com/tonkeeper/tongo"
 	"github.com/tonkeeper/tongo/abi"
 	"github.com/tonkeeper/tongo/boc"
@@ -48,16 +51,18 @@ func (m inMsgCreatedLT) String() string {
 	return fmt.Sprintf("%s_%d", m.account.String(), m.lt)
 }
 
-func extractInMsgCreatedLT(accountID tongo.AccountID, tx *tlb.Transaction) (inMsgCreatedLT, bool) {
-	if tx.Msgs.InMsg.Exists && tx.Msgs.InMsg.Value.Value.Info.IntMsgInfo != nil {
-		return inMsgCreatedLT{account: accountID, lt: tx.Msgs.InMsg.Value.Value.Info.IntMsgInfo.CreatedLt}, true
+func extractInMsgCreatedLT(accountID tongo.AccountID, tx core.Transaction) (inMsgCreatedLT, bool) {
+	if tx.InMsg != nil {
+		return inMsgCreatedLT{account: accountID, lt: tx.InMsg.CreatedLt}, true
 	}
 	return inMsgCreatedLT{}, false
 }
 
 type LiteStorage struct {
-	logger                  *zap.Logger
-	client                  *liteapi.Client
+	logger       *zap.Logger
+	client       *liteapi.Client
+	tonapiClient *tonapi.Client
+
 	executor                abi.Executor
 	jettonMetaCache         *xsync.MapOf[string, tep64.Metadata]
 	transactionsIndexByHash ICache[core.Transaction]
@@ -99,6 +104,7 @@ type Options struct {
 	transactionsIndexByHash ICache[core.Transaction]
 	transactionsByInMsgLT   ICache[string]
 	cacheExpiration         time.Duration
+	tonApiClient            *tonapi.Client
 }
 
 func WithPreloadAccounts(a []tongo.AccountID) Option {
@@ -156,6 +162,12 @@ func WithCacheExpiration(d time.Duration) Option {
 	}
 }
 
+func WithTonApiClient(c *tonapi.Client) Option {
+	return func(o *Options) {
+		o.tonApiClient = c
+	}
+}
+
 type Option func(o *Options)
 
 func NewLiteStorage(log *zap.Logger, cli *liteapi.Client, opts ...Option) (*LiteStorage, error) {
@@ -171,6 +183,7 @@ func NewLiteStorage(log *zap.Logger, cli *liteapi.Client, opts ...Option) (*Lite
 		// TODO: introduce an env variable to configure this number
 		maxGoroutines: 5,
 		client:        cli,
+		tonapiClient:  o.tonApiClient,
 		executor:      o.executor,
 		stopCh:        make(chan struct{}),
 		// read-only data
@@ -213,7 +226,6 @@ func NewLiteStorage(log *zap.Logger, cli *liteapi.Client, opts ...Option) (*Lite
 		}
 	})
 	go storage.run(o.blockCh)
-	go storage.runBlockchainConfigUpdate(5 * time.Second)
 	return storage, nil
 }
 
@@ -229,31 +241,29 @@ func (s *LiteStorage) Shutdown() {
 func (s *LiteStorage) ParseBlock(ctx context.Context, block indexer.IDandBlock) {
 	transactionsIndexByHash := map[string]core.Transaction{}
 	transactionsByInMsgLT := map[string]string{}
-	for _, tx := range block.Block.AllTransactions() {
-		accountID := *ton.NewAccountID(block.ID.Workchain, tx.AccountAddr)
+	for _, tx := range block.Transactions {
+		accountID := ton.MustParseAccountID(tx.Account.Address)
 		_, trackSpecificAccount := s.trackingAccounts[accountID]
 		if trackSpecificAccount || s.trackAllAccounts {
-			hash := tongo.Bits256(tx.Hash())
-			transaction, err := core.ConvertTransaction(accountID.Workchain, tongo.Transaction{Transaction: *tx, BlockID: block.ID})
+			transaction, err := OasTransactionToCoreTransaction(tx)
 			if err != nil {
 				s.logger.Error("failed to process tx",
-					zap.String("tx-hash", hash.Hex()),
+					zap.String("tx-hash", tx.Hash),
 					zap.Error(err))
 				continue
 			}
-			transactionsIndexByHash[tx.Hash().Hex()] = *transaction
+			hash := tongo.Bits256(transaction.Hash)
+			transactionsIndexByHash[hash.Hex()] = transaction
 
 			// We save in cache for each transaction:
 			// 1. A map from the incoming message to the transaction hash (used when looking a transaction children)
 			// 2. A map from each outgoing message to the transaction hash (used when looking a transaction parent)
-			if createLT, ok := extractInMsgCreatedLT(accountID, tx); ok {
+			if createLT, ok := extractInMsgCreatedLT(accountID, transaction); ok {
 				transactionsByInMsgLT[createLT.String()] = hash.Hex()
 			}
-			for _, outMsg := range tx.Msgs.OutMsgs.Values() {
-				if outMsg.Value.Info.IntMsgInfo != nil {
-					createLT := inMsgCreatedLT{account: accountID, lt: outMsg.Value.Info.IntMsgInfo.CreatedLt}
-					transactionsByInMsgLT[createLT.String()] = hash.Hex()
-				}
+			for _, outMsg := range transaction.OutMsgs {
+				createLT := inMsgCreatedLT{account: accountID, lt: outMsg.CreatedLt}
+				transactionsByInMsgLT[createLT.String()] = hash.Hex()
 			}
 		}
 	}
@@ -291,20 +301,16 @@ func (s *LiteStorage) GetRawAccount(ctx context.Context, address tongo.AccountID
 		storageTimeHistogramVec.WithLabelValues("get_raw_account").Observe(v)
 	}))
 	defer timer.ObserveDuration()
-	var account tlb.ShardAccount
-	err := retry.Do(func() error {
-		state, err := s.client.GetAccountState(ctx, address)
-		if err != nil {
-			return err
-		}
-		account = state
-		return nil
-	}, retry.Attempts(10), retry.Delay(10*time.Millisecond))
 
+	rawAccount, err := s.tonapiClient.GetBlockchainRawAccount(ctx, tonapi.GetBlockchainRawAccountParams{AccountID: address.ToRaw()})
 	if err != nil {
 		return nil, err
 	}
-	return core.ConvertToAccount(address, account)
+	coreAccount, err := oasAccountToCoreAccount(*rawAccount)
+	if err != nil {
+		return nil, err
+	}
+	return &coreAccount, nil
 }
 
 // GetRawAccounts returns low-level information about several accounts taken directly from the blockchain.
@@ -349,9 +355,9 @@ func (s *LiteStorage) preloadAccount(a tongo.AccountID) error {
 		}
 		hash := tongo.Bits256(tx.Hash())
 		s.transactionsIndexByHash.Set(context.Background(), hash.Hex(), *t, s.cacheExpiration)
-		if createLT, ok := extractInMsgCreatedLT(a, &tx.Transaction); ok {
-			s.transactionsByInMsgLT.Set(context.Background(), createLT.String(), hash.Hex(), s.cacheExpiration)
-		}
+		// if createLT, ok := extractInMsgCreatedLT(a, &tx.Transaction); ok {
+		// 	s.transactionsByInMsgLT.Set(context.Background(), createLT.String(), hash.Hex(), s.cacheExpiration)
+		// }
 	}
 	return nil
 }
@@ -368,19 +374,19 @@ func (s *LiteStorage) preloadBlock(id tongo.BlockID) error {
 	}
 	s.blockCache.Store(extID, &block)
 	for _, tx := range block.AllTransactions() {
-		accountID := tongo.AccountID{
-			Workchain: extID.Workchain,
-			Address:   tx.AccountAddr,
-		}
+		// accountID := tongo.AccountID{
+		// 	Workchain: extID.Workchain,
+		// 	Address:   tx.AccountAddr,
+		// }
 		t, err := core.ConvertTransaction(extID.Workchain, tongo.Transaction{Transaction: *tx, BlockID: extID})
 		if err != nil {
 			return err
 		}
 		hash := tongo.Bits256(tx.Hash())
 		s.transactionsIndexByHash.Set(ctx, hash.Hex(), *t, s.cacheExpiration)
-		if createLT, ok := extractInMsgCreatedLT(accountID, tx); ok {
-			s.transactionsByInMsgLT.Set(ctx, createLT.String(), hash.Hex(), s.cacheExpiration)
-		}
+		// if createLT, ok := extractInMsgCreatedLT(accountID, tx); ok {
+		// 	s.transactionsByInMsgLT.Set(ctx, createLT.String(), hash.Hex(), s.cacheExpiration)
+		// }
 	}
 	return nil
 }
@@ -447,11 +453,11 @@ func (s *LiteStorage) GetTransaction(ctx context.Context, hash tongo.Bits256) (*
 		storageTimeHistogramVec.WithLabelValues("get_transaction").Observe(v)
 	}))
 	defer timer.ObserveDuration()
-	tx, err := s.transactionsIndexByHash.Get(ctx, hash.Hex())
+	tx, err := s.getTxFromCacheByHash(hash.Hex())
 	if err != nil {
-		return nil, core.ErrEntityNotFound
+		return nil, err
 	}
-	return &tx, nil
+	return tx, nil
 }
 
 func (s *LiteStorage) SearchTransactionByMessageHash(ctx context.Context, hash tongo.Bits256) (*tongo.Bits256, error) {
@@ -487,16 +493,44 @@ func (s *LiteStorage) GetBlockTransactions(ctx context.Context, id tongo.BlockID
 	return core.ExtractTransactions(blockID, &block)
 }
 
+func (s *LiteStorage) getTxFromCacheByHash(hash string) (*core.Transaction, error) {
+	tx, err := s.transactionsIndexByHash.Get(context.Background(), hash)
+	if err != nil {
+		return nil, core.ErrEntityNotFound
+	}
+
+	// Message contain decoded message body which are of type Any
+	// This means that after we saved them to the cache, and reread them, we get them back as a map
+	// we re parse them here to get their actual type back
+	if tx.InMsg != nil {
+		rawBody := hex.EncodeToString(tx.InMsg.Body)
+		decodeMessageBody, err := decodeMessageBody(rawBody, tx.InMsg.MsgType)
+		if err != nil {
+			return nil, err
+		}
+		tx.InMsg.DecodedBody = decodeMessageBody
+	}
+	for i := range tx.OutMsgs {
+		rawBody := hex.EncodeToString(tx.OutMsgs[i].Body)
+		decodeMessageBody, err := decodeMessageBody(rawBody, tx.OutMsgs[i].MsgType)
+		if err != nil {
+			return nil, err
+		}
+		tx.OutMsgs[i].DecodedBody = decodeMessageBody
+	}
+	return &tx, nil
+}
+
 func (s *LiteStorage) searchTxInCache(a tongo.AccountID, lt uint64) *core.Transaction {
 	hash, err := s.transactionsByInMsgLT.Get(context.Background(), inMsgCreatedLT{account: a, lt: lt}.String())
 	if err != nil {
 		return nil
 	}
-	tx, err := s.transactionsIndexByHash.Get(context.Background(), hash)
+	tx, err := s.getTxFromCacheByHash(hash)
 	if err != nil {
 		return nil
 	}
-	return &tx
+	return tx
 }
 
 func (s *LiteStorage) GetStorageProviders(ctx context.Context) ([]core.StorageProvider, error) {
@@ -609,4 +643,249 @@ func (s *LiteStorage) GetAccountMultisigs(ctx context.Context, accountID ton.Acc
 
 func (s *LiteStorage) GetMultisigByID(ctx context.Context, accountID ton.AccountID) (*core.Multisig, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+func OasTransactionToCoreTransaction(oasTransaction tonapi.Transaction) (core.Transaction, error) {
+	transactionId := core.TransactionID{
+		Hash:    tongo.MustParseHash(oasTransaction.Hash),
+		Lt:      uint64(oasTransaction.Lt),
+		Account: tongo.MustParseAddress(oasTransaction.Account.GetAddress()).ID,
+	}
+
+	coreTransaction := core.Transaction{
+		TransactionID: transactionId,
+		Type:          core.TransactionType(oasTransaction.TransactionType),
+		Success:       oasTransaction.Success,
+		Utime:         oasTransaction.Utime,
+		OrigStatus:    tlb.AccountStatus(oasTransaction.OrigStatus),
+		EndStatus:     tlb.AccountStatus(oasTransaction.EndStatus),
+		BlockID:       tongo.MustParseBlockID(oasTransaction.Block),
+		EndBalance:    oasTransaction.EndBalance,
+		Aborted:       oasTransaction.Aborted,
+		Destroyed:     oasTransaction.Destroyed,
+		TotalFee:      oasTransaction.TotalFees,
+	}
+
+	oldHash := tlb.Bits256{}
+	bytes, err := hex.DecodeString(oasTransaction.StateUpdateOld)
+	if err != nil {
+		return core.Transaction{}, err
+	}
+	copy(oldHash[:], bytes)
+
+	newHash := tlb.Bits256{}
+	bytes, err = hex.DecodeString(oasTransaction.StateUpdateNew)
+	if err != nil {
+		return core.Transaction{}, err
+	}
+	copy(newHash[:], bytes)
+
+	coreTransaction.StateHashUpdate = tlb.HashUpdate{
+		OldHash: oldHash,
+		NewHash: newHash,
+	}
+
+	coreTransaction.Raw, err = hex.DecodeString(oasTransaction.Raw)
+	if err != nil {
+		return core.Transaction{}, err
+	}
+
+	if oasTransaction.InMsg.Set {
+		coreMessage, err := oasMessageToCoreMessage(oasTransaction.InMsg.Value)
+		if err != nil {
+			return core.Transaction{}, err
+		}
+		coreTransaction.InMsg = &coreMessage
+	}
+	for _, outMessage := range oasTransaction.OutMsgs {
+		coreMessage, err := oasMessageToCoreMessage(outMessage)
+		if err != nil {
+			return core.Transaction{}, err
+		}
+		coreTransaction.OutMsgs = append(coreTransaction.OutMsgs, coreMessage)
+	}
+
+	if oasTransaction.PrevTransLt.Set && oasTransaction.PrevTransHash.Set {
+		coreTransaction.PrevTransLt = uint64(oasTransaction.PrevTransLt.Value)
+		coreTransaction.PrevTransHash = tongo.MustParseHash(oasTransaction.PrevTransHash.Value)
+	}
+
+	if oasTransaction.ComputePhase.Set {
+		oasComputePhase := oasTransaction.ComputePhase.Value
+		computePhase := core.TxComputePhase{
+			Skipped: oasComputePhase.Skipped,
+		}
+		if oasComputePhase.Skipped {
+			computePhase.SkipReason = tlb.ComputeSkipReason(oasComputePhase.SkipReason.Value)
+		} else {
+			computePhase.Success = oasComputePhase.Success.Value
+			computePhase.GasFees = uint64(oasComputePhase.GasFees.Value)
+			computePhase.GasUsed = *big.NewInt(oasComputePhase.GasUsed.Value)
+			computePhase.VmSteps = uint32(oasComputePhase.VMSteps.Value)
+			computePhase.ExitCode = int32(oasComputePhase.ExitCode.Value)
+		}
+		coreTransaction.ComputePhase = &computePhase
+	}
+
+	if oasTransaction.StoragePhase.Set {
+		oasStoragePhase := oasTransaction.StoragePhase.Value
+		storagePhase := core.TxStoragePhase{
+			StorageFeesCollected: uint64(oasStoragePhase.FeesCollected),
+			StatusChange:         tlb.AccStatusChange(oasStoragePhase.StatusChange),
+		}
+		if oasStoragePhase.FeesDue.Set {
+			storageFeesDue := uint64(oasStoragePhase.FeesDue.Value)
+			storagePhase.StorageFeesDue = &storageFeesDue
+		}
+		coreTransaction.StoragePhase = &storagePhase
+	}
+
+	if oasTransaction.CreditPhase.Set {
+		oasCreditPhase := oasTransaction.CreditPhase.Value
+		creditPhase := core.TxCreditPhase{
+			DueFeesCollected: uint64(oasCreditPhase.FeesCollected),
+			CreditGrams:      uint64(oasCreditPhase.Credit),
+		}
+		coreTransaction.CreditPhase = &creditPhase
+	}
+
+	if oasTransaction.ActionPhase.Set {
+		oasActionPhase := oasTransaction.ActionPhase.Value
+		actionPhase := core.TxActionPhase{
+			Success:        oasActionPhase.Success,
+			ResultCode:     int32(oasActionPhase.ResultCode),
+			TotalActions:   uint16(oasActionPhase.TotalActions),
+			SkippedActions: uint16(oasActionPhase.SkippedActions),
+			FwdFees:        uint64(oasActionPhase.FwdFees),
+			TotalFees:      uint64(oasActionPhase.TotalFees),
+		}
+		coreTransaction.ActionPhase = &actionPhase
+	}
+
+	if oasTransaction.BouncePhase.Set {
+		oasBouncePhase := oasTransaction.BouncePhase.Value
+		bouncePhase := core.TxBouncePhase{
+			Type: core.BouncePhaseType(oasBouncePhase),
+		}
+		coreTransaction.BouncePhase = &bouncePhase
+	}
+	return coreTransaction, nil
+}
+
+func oasMessageToCoreMessage(oasMessage tonapi.Message) (core.Message, error) {
+	messageId := core.MessageID{
+		CreatedLt: uint64(oasMessage.CreatedLt),
+	}
+	if oasMessage.Source.Set {
+		accountId := tongo.MustParseAddress(oasMessage.Source.Value.Address).ID
+		messageId.Source = &accountId
+	}
+	if oasMessage.Destination.Set {
+		accountId := tongo.MustParseAddress(oasMessage.Destination.Value.Address).ID
+		messageId.Destination = &accountId
+	}
+
+	coreMessage := core.Message{
+		MessageID:   messageId,
+		Hash:        tongo.MustParseHash(oasMessage.Hash),
+		IhrDisabled: oasMessage.IhrDisabled,
+		Bounce:      oasMessage.Bounce,
+		Bounced:     oasMessage.Bounced,
+		Value:       oasMessage.Value,
+		FwdFee:      oasMessage.FwdFee,
+		IhrFee:      oasMessage.IhrFee,
+		ImportFee:   oasMessage.ImportFee,
+		CreatedAt:   uint32(oasMessage.CreatedAt),
+	}
+
+	if oasMessage.MsgType == tonapi.MessageMsgTypeExtInMsg {
+		coreMessage.MsgType = core.ExtInMsg
+	} else if oasMessage.MsgType == tonapi.MessageMsgTypeExtOutMsg {
+		coreMessage.MsgType = core.ExtOutMsg
+	} else {
+		coreMessage.MsgType = core.IntMsg
+	}
+
+	if oasMessage.RawBody.Set {
+		decodedMessageBody, err := decodeMessageBody(oasMessage.RawBody.Value, coreMessage.MsgType)
+		if err != nil {
+			return core.Message{}, err
+		}
+		coreMessage.DecodedBody = decodedMessageBody
+	}
+
+	if oasMessage.Init.Set {
+		coreMessage.Init, _ = hex.DecodeString(oasMessage.Init.Value.Boc)
+		for _, iface := range oasMessage.Init.Value.Interfaces {
+			coreMessage.InitInterfaces = append(coreMessage.InitInterfaces, abi.ContractInterfaceFromString(iface))
+		}
+	}
+
+	if oasMessage.RawBody.Set {
+		var err error
+		coreMessage.Body, err = hex.DecodeString(oasMessage.RawBody.Value)
+		if err != nil {
+			return core.Message{}, err
+		}
+	}
+
+	if oasMessage.OpCode.Set {
+		bytes, err := hex.DecodeString(oasMessage.OpCode.Value[2:])
+		if err != nil {
+			return core.Message{}, err
+		}
+		opCode := binary.BigEndian.Uint32(bytes)
+		coreMessage.OpCode = &opCode
+	}
+	return coreMessage, nil
+}
+
+func oasAccountToCoreAccount(oasAccount tonapi.BlockchainRawAccount) (core.Account, error) {
+	coreAccount := core.Account{
+		AccountAddress:    tongo.MustParseAddress(oasAccount.Address).ID,
+		Status:            tlb.AccountStatus(oasAccount.Status),
+		TonBalance:        oasAccount.Balance,
+		LastTransactionLt: uint64(oasAccount.LastTransactionLt),
+	}
+	if oasAccount.Code.Set {
+		var err error
+		coreAccount.Code, err = hex.DecodeString(oasAccount.Code.Value)
+		if err != nil {
+			return core.Account{}, err
+		}
+	}
+	return coreAccount, nil
+}
+
+func decodeMessageBody(rawBody string, msgType core.MsgType) (*core.DecodedMessageBody, error) {
+	if rawBody == "" {
+		return nil, nil
+	}
+
+	cells, err := boc.DeserializeBocHex(rawBody)
+	if err != nil {
+		return nil, err
+	}
+	if len(cells) != 1 {
+		return nil, errors.New("multiple cells not supported")
+	}
+	cell := cells[0]
+
+	var op *string
+	var value any
+	switch msgType {
+	case "IntMsg":
+		_, op, value, err = abi.InternalMessageDecoder(cell, nil)
+	case "ExtInMsg":
+		_, op, value, err = abi.ExtInMessageDecoder(cell, nil)
+	case "ExtOutMsg":
+		_, op, value, err = abi.ExtOutMessageDecoder(cell, nil, tlb.MsgAddress{})
+	}
+	if err != nil {
+		return nil, err
+	}
+	if op != nil {
+		return &core.DecodedMessageBody{Operation: *op, Value: value}, nil
+	}
+	return nil, nil
 }

--- a/pkg/litestorage/trace.go
+++ b/pkg/litestorage/trace.go
@@ -9,9 +9,46 @@ import (
 	"github.com/tonkeeper/tongo"
 	"github.com/tonkeeper/tongo/abi"
 	"github.com/tonkeeper/tongo/boc"
+	"github.com/tonkeeper/tongo/ton"
 
 	"github.com/arnac-io/opentonapi/pkg/core"
 )
+
+// Taken from https://github.com/tonkeeper/tongo/blob/master/abi/interfaces.go#L1018
+var knownContracts = map[ton.Bits256]abi.ContractInterface{
+	ton.MustParseHash("0dceed21269d66013e95b19fbb5c55a6f01adad40837baa8e521cde3a02aa46c"): abi.WalletHighloadV1R2,
+	ton.MustParseHash("11acad7955844090f283bf238bc1449871f783e7cc0979408d3f4859483e8525"): abi.WalletHighloadV3R1,
+	ton.MustParseHash("1bd9c5a39bffb7a0f341588b5dd92b813a842bf65ef14109382200ceaf8f72df"): abi.NftAuctionGetgemsV3,
+	ton.MustParseHash("203dd4f358adb49993129aa925cac39916b68a0e4f78d26e8f2c2b69eafa5679"): abi.WalletHighloadV2R2,
+	ton.MustParseHash("20834b7b72b112147e1b2fb457b84e74d1a30f04f737d4f62a668e9552d2b72f"): abi.WalletV5R1,
+	ton.MustParseHash("24221fa571e542e055c77bedfdbf527c7af460cfdc7f344c450787b4cfa1eb4d"): abi.NftSaleGetgemsV3,
+	ton.MustParseHash("32050dfac44f64866bcc86f2cd9e1305fe9dcadb3959c002237cfb0902d44323"): abi.NftSaleGetgemsV3,
+	ton.MustParseHash("45ebbce9b5d235886cb6bfe1c3ad93b708de058244892365c9ee0dfe439cb7b5"): abi.WalletPreprocessedV2,
+	ton.MustParseHash("4c9123828682fa6f43797ab41732bca890cae01766e0674100250516e0bf8d42"): abi.NftItemSimple,
+	ton.MustParseHash("587cc789eff1c84f46ec3797e45fc809a14ff5ae24f1e0c7a6a99cc9dc9061ff"): abi.WalletV1R3,
+	ton.MustParseHash("5c9a5e68c108e18721a07c42f9956bfb39ad77ec6d624b60c576ec88eee65329"): abi.WalletV2R1,
+	ton.MustParseHash("64dd54805522c5be8a9db59cea0105ccf0d08786ca79beb8cb79e880a8d7322d"): abi.WalletV4R1,
+	ton.MustParseHash("6668872fa79705443ffd47523e8e9ea9f76ab99f9a0b59d27de8f81a1c27b9d4"): abi.NftAuctionGetgemsV3,
+	ton.MustParseHash("8278f4c5233de6fbedc969af519344a7a9bffc544856dba986a95c0bcf8571c9"): abi.NftSaleGetgemsV2,
+	ton.MustParseHash("84dafa449f98a6987789ba232358072bc0f76dc4524002a5d0918b9a75d2d599"): abi.WalletV3R2,
+	ton.MustParseHash("89468f02c78e570802e39979c8516fc38df07ea76a48357e0536f2ba7b3ee37b"): abi.JettonWalletGoverned,
+	ton.MustParseHash("8ceb45b3cd4b5cc60eaae1c13b9c092392677fe536b2e9b2d801b62eff931fe1"): abi.WalletHighloadV2R1,
+	ton.MustParseHash("8d28ea421b77e805fea52acf335296499f03aec8e9fd21ddb5f2564aa65c48de"): abi.JettonWalletV2,
+	ton.MustParseHash("9494d1cc8edf12f05671a1a9ba09921096eb50811e1924ec65c3c629fbb80812"): abi.WalletHighloadV2,
+	ton.MustParseHash("a01e057fbd4288402b9898d78d67bd4e90254c93c5866879bc2d1d12865436bc"): abi.MultisigOrderV2,
+	ton.MustParseHash("a0cfc2c48aee16a271f2cfc0b7382d81756cecb1017d077faaab3bb602f6868c"): abi.WalletV1R1,
+	ton.MustParseHash("b61041a58a7980b946e8fb9e198e3c904d24799ffa36574ea4251c41a566f581"): abi.WalletV3R1,
+	ton.MustParseHash("beb0683ebeb8927fe9fc8ec0a18bc7dd17899689825a121eab46c5a3a860d0ce"): abi.JettonWalletV1,
+	ton.MustParseHash("ccae6ffb603c7d3e779ab59ec267ffc22dc1ebe0af9839902289a7a83e4c00f1"): abi.GramMiner,
+	ton.MustParseHash("d3d14da9a627f0ec3533341829762af92b9540b21bf03665fac09c2b46eabbac"): abi.MultisigV2,
+	ton.MustParseHash("d4902fcc9fad74698fa8e353220a68da0dcf72e32bcb2eb9ee04217c17d3062c"): abi.WalletV1R2,
+	ton.MustParseHash("d8cdbbb79f2c5caa677ac450770be0351be21e1250486de85cc52aa33dd16484"): abi.WalletHighloadV1R1,
+	ton.MustParseHash("deb53b6c5765c1e6cd238bf47bc5e83ba596bdcc04b0b84cd50ab1e474a08f31"): abi.NftSaleGetgemsV3,
+	ton.MustParseHash("e4cf3b2f4c6d6a61ea0f2b5447d266785b26af3637db2deee6bcd1aa826f3412"): abi.WalletV5Beta,
+	ton.MustParseHash("f3d7ca53493deedac28b381986a849403cbac3d2c584779af081065af0ac4b93"): abi.WalletV5Beta,
+	ton.MustParseHash("fe9530d3243853083ef2ef0b4c2908c0abf6fa1c31ea243aacaa5bf8c7d753f1"): abi.WalletV2R2,
+	ton.MustParseHash("feb5ff6820e2ff0d9483e7e0d62c817d846789fb4ae580c878866d959dabd5c0"): abi.WalletV4R2,
+}
 
 const (
 	maxDepthLimit = 1024
@@ -165,12 +202,44 @@ func (s *LiteStorage) getAccountInterfaces(ctx context.Context, id tongo.Account
 		}
 		emulatedAccountCode.WithLabelValues(h).Inc()
 	}
-	inspector := abi.NewContractInspector(abi.InspectWithLibraryResolver(s))
-	cd, err := inspector.InspectContract(ctx, account.Code, s.executor, id)
+	contractInterface, err := InspectContract(account.Code)
 	if err != nil {
 		return nil, err
 	}
-	interfaces = cd.ContractInterfaces
+	if contractInterface == nil {
+		return nil, nil
+	}
+	interfaces = []abi.ContractInterface{*contractInterface}
 	s.accountInterfacesCache.Store(id, interfaces)
 	return interfaces, nil
+}
+
+func InspectContract(code []byte) (*abi.ContractInterface, error) {
+	// Originally the code was:
+	// inspector := abi.NewContractInspector(abi.InspectWithLibraryResolver(s))
+	// cd, err := inspector.InspectContract(ctx, account.Code, s.executor, id)
+	// That contains a more complex logic, for finding the interface using both hardcoded known contracts hashes,
+	// and by manually inspecting and trying all known methods, of the contract
+	// This also contained more complext logic for getting extra data that isn't really needed,
+	// so we can simplify it to comparing to the known contract hashes
+	if len(code) == 0 {
+		return nil, nil
+	}
+	cells, err := boc.DeserializeBoc(code)
+	if err != nil {
+		return nil, err
+	}
+	if len(cells) == 0 {
+		return nil, fmt.Errorf("failed to find a root cell")
+	}
+	root := cells[0]
+	codeHash, err := root.Hash256()
+	if err != nil {
+		return nil, err
+	}
+
+	if contractInterface, ok := knownContracts[codeHash]; ok {
+		return &contractInterface, nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
This PR removes the parsing dependency of ADNL connection

originally, it would query blocks and transaction in TLB format which obtained from direct ADNL connection and parse those into high level events

we replace all those calls and access with API calls of the same opentonapi pacakge run by some provider

the API implementation we call, is actually to use ADNL to get TLB format, and convert it to some model and return it as the response
we reversed engineered it, and construct back the TLB format from the API response

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arnac-io/opentonapi/7)
<!-- Reviewable:end -->
