### PR TITLE
fix: don't drop trace child when getAccountInterfaces fails

### DIFF
--- a/pkg/litestorage/trace.go
+++ b/pkg/litestorage/trace.go
@@ -116,11 +116,11 @@ func (s *LiteStorage) recursiveGetChildren(ctx context.Context, tx core.Transact
 		}
 		trace.Children = append(trace.Children, &child)
 	}
-	var err error
-	trace.AccountInterfaces, err = s.getAccountInterfaces(ctx, tx.Account)
+	accountInterfaces, err := s.getAccountInterfaces(ctx, tx.Account)
 	if err != nil {
-		return core.Trace{}, nil
+		s.logger.Warn(fmt.Sprintf("Failed to get account interfaces for %v, continuing with empty interfaces: %v", tx.Account, err))
 	}
+	trace.AccountInterfaces = accountInterfaces
 	trace.OutMsgs = externalMessages
 	return trace, nil
 }


### PR DESCRIPTION
## Summary

- Fix a bug in `litestorage/trace.go` where `recursiveGetChildren` silently drops an entire trace child (including CreditPhase, InMsg, all transaction data) when `getAccountInterfaces` fails
- Instead of returning an empty `core.Trace{}` with nil error, log a warning and continue with empty interfaces

## Root Cause

`getAccountInterfaces` calls `GetRawAccount` on the liteserver, which can intermittently fail for `nonexist` accounts (accounts that have never been touched on-chain). When this happens:

**Before:** `return core.Trace{}, nil` — the real child trace is replaced with an empty shell. The parent appends this empty trace as a child, losing all transaction data (CreditPhase, InMsg.Value, etc).

**After:** Log a warning, set `AccountInterfaces = nil`, and return the full trace. Accounts without code correctly get nil interfaces — no straw depends on `HasInterface` for such accounts.

## Impact

This caused a rare flaky E2E test failure (`TestTonIncomingTransaction::test_ton_incoming_jetton_transfer`). When a jetton transfer notification arrives at a `nonexist` vault account:
- The vault notification's `CreditPhase.CreditGrams = 1` (1 nanoton) was lost
- The Event ValueFlow showed `ton: 0` instead of `ton: 1` for the vault
- The incoming transaction was indexed with 1 balance_change (jetton only) instead of 2 (native + jetton)

Evidence from CI logs comparing passing vs failing runs:
- **TON blockchain data**: identical in both runs (`credit_grams=1, total_fees=0, nonexist→uninitialized`)
- **opentonapi Event ValueFlow**: `ton=1, fees=0` (passing) vs `ton=0, fees=0` (failing)
- **recv_wal native TON**: `+30,914,999` (passing, deducted 1 for notification) vs `+30,915,000` (failing, no deduction — notification child was empty)

## Test plan

- [x] Verify `go build ./pkg/litestorage/` compiles clean
- [x] Run existing tests
- [x] Deploy and monitor for the warning log in E2E environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arnac-io/opentonapi/26)
<!-- Reviewable:end -->
