### PR TITLE
Don't log init-chunk failures the caller already handles [DEV-26086]

### DIFF
--- a/pkg/blockchain/indexer/indexer.go
+++ b/pkg/blockchain/indexer/indexer.go
@@ -86,7 +86,6 @@ func (idx *Indexer) Run(ctx context.Context, channels []chan IDandBlock) {
 func (idx *Indexer) GetBlocksFromMasterBlock(masterBlockNumber uint32) (IDandBlock, []IDandBlock, error) {
 	chunk, err := idx.initChunk(masterBlockNumber)
 	if err != nil {
-		idx.logger.Error("failed to get init chunk", zap.Error(err))
 		return IDandBlock{}, nil, err
 	}
 	workChainBlocks := []IDandBlock{}


### PR DESCRIPTION
## Summary

`GetBlocksFromMasterBlock` logs `failed to get init chunk` at Error level and then also returns the error to its caller. The caller in arnac (`services/blockchain/indexer/block_parser/ton/block_parser.go`) inspects that error, maps tonapi's 404 to a temporary handling error, and retries — successfully. So the Error log is a pure duplicate of an error that is already handled.

In production this was **702 error logs in 24h** on `ton-mainnet-indexer`, 74% of all indexer error volume across every chain, with zero corresponding handling failures. Cause is a normal head race: our streamer publishes the masterchain head before tonapi.io's indexer has it, so `GetBlockchainMasterchainBlocks` answers `404 entity not found`.

## What is kept

The identical log in `Run()` stays. That loop swallows the error (`continue`) and is used by `cmd/api`, so it is the only record of the failure there — removing it would lose information.

## Test plan

- [x] `go build ./pkg/blockchain/indexer/`
- [ ] After the arnac pin bump: confirm `service:ton-mainnet-indexer status:error` volume drops to ~0 in production while TON indexing stays healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arnac-io/opentonapi/27)
<!-- Reviewable:end -->
